### PR TITLE
Ability to Generate First Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Generate release notes from closed issues and merged pull requests, and create a
 new release on GitHub.
 
-![Release Notes Example](./docs/screenshot.png)
+![Release Notes Example](docs/screenshot.png)
 
 ## Installation
 
@@ -18,37 +18,49 @@ determine how to find the closed issues and pull requests.
 
 **Arguments:**
 
-  * `--repo` the repo in the format `username/project`
-  * `--prev` the previous release tag name (must exist on GitHub)
-  * `--new` the new release tag name (must exist on GitHub)
-  * `--token` your GitHub API token, which you can generate in [your settings page on GitHub](https://github.com/settings/applications).
+- `--repo` the repo in the format `username/project`
+- `--prev` the previous release tag name (must exist on GitHub)
+- `—init` create the first release for the repo
+- `--new` the new release tag name (must exist on GitHub)
+- `--token` your GitHub API token, which you can generate in [your settings page on GitHub](https://github.com/settings/applications).
 
-Once you have the required arguments, you can simply run:
+You can either generate your very first release, or create a new release from a
+previous tag and the new release.
+
+Closed issues and pull requests are included in the release notes.
+
+- Issues closed by a pull request are **excluded**
+- Issues closed by a commit, but not a pull request are **included**
+- All other issues are **excluded**
+- Pull requests
+
+### Generate First Release
+
+This will generate the very first release for a repository, you simply skip the
+`--prev` option and specify `--init` instead:
+
+    hubrelease --repo zestia/hubrelease --new v0.0.1 --init --token $GITHUB_API_TOKEN
+
+### Generate New Release
+
+This will generate a new release after the first:
 
     hubrelease --repo zestia/hubrelease --prev v0.1.0 --new v0.2.0 --token $GITHUB_API_TOKEN
 
-This will either create a new release or update an existing release. The release
-will include a list of closed issues and pull requests.
-
-The included issues and pull requests are based on certain criterea:
-
-  * Issues closed by a pull request are **excluded**
-  * Issues closed by a commit, but not a pull request are **included**
-  * All other issues are **excluded**
-  * Pull requests
+This will either create a new release or update an existing release.
 
 ## Contribute
 
 Here's the most direct way to get your work merged into the project:
 
-  * Fork the project
-  * Clone down your fork
-  * Create a feature branch
-  * Hack away
-  * If necessary, rebase your commits into logical chunks, without errors
-  * Push the branch up
-  * Send a pull request for your branch
+- Fork the project
+- Clone down your fork
+- Create a feature branch
+- Hack away
+- If necessary, rebase your commits into logical chunks, without errors
+- Push the branch up
+- Send a pull request for your branch
 
-## License
+##  License
 
 See `LICENSE` for more details.

--- a/bin/hubrelease
+++ b/bin/hubrelease
@@ -14,6 +14,10 @@ opts = OptionParser.new do |o|
     options[:repo] = repo
   end
 
+  o.on "--init", "Generate first release" do |init|
+    options[:init] = init
+  end
+
   o.on "--output", "Print release notes to stdout, don't create a GitHub release" do |output|
     options[:output] = output
   end
@@ -38,7 +42,13 @@ end
 
 begin
   opts.parse!
-  mandatory = [:repo, :prev, :new, :token]
+
+  if options[:init]
+    mandatory = [:repo, :token, :new]
+  else
+    mandatory = [:repo, :prev, :new, :token]
+  end
+
   missing = mandatory.select{ |param| options[param].nil? }
 
   unless missing.empty?
@@ -52,4 +62,4 @@ rescue OptionParser::InvalidOption, OptionParser::MissingArgument
   exit
 end
 
-HubRelease::Generator.new(options).generate
+HubRelease::Generator.generate(options)

--- a/lib/hubrelease.rb
+++ b/lib/hubrelease.rb
@@ -1,121 +1,20 @@
 require "octokit"
 
+require "hubrelease/generator"
+require "hubrelease/issues"
+require "hubrelease/releases"
+require "hubrelease/version"
+
 module HubRelease
-  class Generator
-    CLOSE_REGEX = /(((close|resolve)(s|d)?)|fix(e(s|d))?) #(\d+)/i
+  class << self
+    attr_reader :client, :repo
 
-    def initialize(options)
-      @client = Octokit::Client.new access_token: options[:token]
-      @repo = options[:repo]
-      @base_tag = options[:prev]
-      @head_tag = options[:new]
-      @output = options[:output]
+    def client=(client)
+      @client = client
     end
 
-    def generate
-      base_ref = fetch_base_tag
-      head_ref = fetch_head_tag
-
-      base_date = (base_ref.tagger ? base_ref.tagger.date : base_ref.author.date)
-      head_date = (head_ref.tagger ? head_ref.tagger.date : head_ref.author.date)
-
-      issues = fetch_issues(base_date, head_date)
-
-      issues = exclude_closed_by_pull_request(issues)
-      issues = exclude_non_merged_pull_requests(issues)
-      issues = include_closed_by_commit(issues)
-
-      body = generate_release_body(issues)
-
-      if @output
-        puts body
-      else
-        create_or_update_release(body)
-      end
-    end
-
-    def fetch_base_tag
-      base = @client.ref @repo, "tags/#{@base_tag}"
-      @client.get base.object.url
-    rescue Octokit::NotFound
-      abort "Could not find base tag #{@base_tag} - make sure the tag has been pushed"
-    end
-
-    def fetch_head_tag
-      head = @client.ref @repo, "tags/#{@head_tag}"
-      @client.get head.object.url
-    rescue Octokit::NotFound
-      abort "Could not find head tag #{@head_tag} - make sure the tag has been pushed"
-    end
-
-    def fetch_issues(since, before)
-      issues = @client.issues @repo, { state: "closed", since: since.iso8601 }
-      issues = issues.select { |i| i.closed_at <= before }
-    end
-
-    def exclude_closed_by_pull_request(issues)
-      exclude_ids = issues.map do |issue|
-        if issue.pull_request
-          if match = CLOSE_REGEX.match(issue.body)
-            match[7].to_i
-          end
-        end
-      end.compact.uniq
-
-      issues.select do |issue|
-        !exclude_ids.include?(issue.number)
-      end
-    end
-
-    def exclude_non_merged_pull_requests(issues)
-      exclude_ids = issues.map do |issue|
-        if issue.pull_request
-          pr = @client.get issue.pull_request.url
-
-          unless pr.merged_at
-            issue.number
-          end
-        end
-      end.compact.uniq
-
-      issues.select do |issue|
-        !exclude_ids.include?(issue.number)
-      end
-    end
-
-    def include_closed_by_commit(issues)
-      compare = @client.compare @repo, @base_tag, @head_tag
-
-      include_ids = compare.commits.map do |commit|
-        if match = CLOSE_REGEX.match(commit.commit.message)
-          match[7].to_i
-        end
-      end.compact.uniq
-
-      issues.select do |issue|
-        include_ids.include?(issue.number) || issue.pull_request
-      end
-    end
-
-    def generate_release_body(issues)
-      issues.map do |issue|
-        "[##{issue.number}](#{issue.html_url}) - #{issue.title}"
-      end.join("\n")
-    end
-
-    def create_or_update_release(body)
-      release = @client.release_for_tag @repo, @head_tag
-      raise Octokit::NotFound if release.id.nil?
-
-      puts "Updating release #{@head_tag}..."
-
-      @client.update_release release.url, name: @head_tag, body: body
-      puts release.html_url
-    rescue Octokit::NotFound
-      puts "Creating release #{@head_tag}..."
-
-      release = @client.create_release @repo, @head_tag, name: @head_tag, body: body
-      puts release.html_url
+    def repo=(repo)
+      @repo = repo
     end
   end
 end

--- a/lib/hubrelease/generator.rb
+++ b/lib/hubrelease/generator.rb
@@ -1,0 +1,71 @@
+module HubRelease
+  module Generator
+    class << self
+      def generate(options)
+        HubRelease.client = Octokit::Client.new access_token: options[:token]
+        HubRelease.repo = options[:repo]
+
+        @output = options[:output]
+        @base_tag = options[:prev]
+        @head_tag = options[:new]
+
+        if options[:init]
+          generate_first
+        else
+          generate_new
+        end
+      end
+
+      def generate_first
+        current = before_date(@head_tag)
+
+        issues = HubRelease::Issues.fetch
+        issues = filter_issues(issues, current)
+
+        if @output
+          HubRelease::Releases.output(issues)
+        else
+          HubRelease::Releases.create_or_update(@head_tag, issues)
+        end
+      end
+
+      def generate_new
+        since = since_date(@base_tag)
+        current = before_date(@head_tag)
+
+        issues = HubRelease::Issues.fetch(since)
+        issues = filter_issues(issues, current)
+
+        if @output
+          HubRelease::Releases.output(issues)
+        else
+          HubRelease::Releases.create_or_update(@head_tag, issues)
+        end
+      end
+
+      def since_date(tag)
+        base_ref = fetch_tag_ref(tag)
+        base_ref.tagger ? base_ref.tagger.date : base_ref.author.date
+      end
+
+      def before_date(tag)
+        head_ref = fetch_tag_ref(tag)
+        head_ref.tagger ? head_ref.tagger.date : head_ref.author.date
+      end
+
+      def fetch_tag_ref(tag)
+        ref = HubRelease.client.ref(HubRelease.repo, "tags/#{tag}")
+        HubRelease.client.get(ref.object.url)
+      rescue Octokit::NotFound
+        abort "Could not fetch tag reference #{tag}"
+      end
+
+      def filter_issues(issues, current)
+        issues = HubRelease::Issues.filter_closed_after(issues, current)
+        issues = HubRelease::Issues.filter_closed_by_pull_request(issues)
+        issues = HubRelease::Issues.filter_non_merged_pull_requests(issues)
+        issues = HubRelease::Issues.filter_non_commit_closed(issues, @base_tag || "master", @head_tag)
+      end
+    end
+  end
+end

--- a/lib/hubrelease/issues.rb
+++ b/lib/hubrelease/issues.rb
@@ -1,0 +1,53 @@
+module HubRelease
+  module Issues
+    CLOSE_REGEX = /(((close|resolve)(s|d)?)|fix(e(s|d))?) #(\d+)/i
+
+    def self.fetch(since = nil)
+      params = { state: "closed" }
+      params[:since] = since.iso8601 unless since.nil?
+      HubRelease.client.issues(HubRelease.repo, params)
+    end
+
+    def self.filter_closed_after(issues, date)
+      issues.select { |i| i.closed_at <= date }
+    end
+
+    def self.filter_closed_by_pull_request(issues)
+      ids = issues.map do |i|
+        if i.pull_request
+          if match = CLOSE_REGEX.match(i.body)
+            match[7].to_i
+          end
+        end
+      end.compact.uniq
+
+      issues.select { |i| !ids.include?(i.number) }
+    end
+
+    def self.filter_non_merged_pull_requests(issues)
+      ids = issues.map do |i|
+        if i.pull_request
+          pr = HubRelease.client.get(i.pull_request.url)
+
+          unless pr.merged_at
+            i.number
+          end
+        end
+      end.compact.uniq
+
+      issues.select { |i| !ids.include?(i.number) }
+    end
+
+    def self.filter_non_commit_closed(issues, base, head)
+      compare = HubRelease.client.compare(HubRelease.repo, base, head)
+
+      ids = compare.commits.map do |c|
+        if match = CLOSE_REGEX.match(c.commit.message)
+          match[7].to_i
+        end
+      end.compact.uniq
+
+      issues.select { |i| ids.include?(i.number) || i.pull_request }
+    end
+  end
+end

--- a/lib/hubrelease/releases.rb
+++ b/lib/hubrelease/releases.rb
@@ -1,0 +1,41 @@
+module HubRelease
+  module Releases
+    def self.output(issues)
+      puts generate_body(issues)
+    end
+
+    def self.create_or_update(tag, issues)
+      release = HubRelease.client(HubRelease.repo, tag)
+      raise Octokit::NotFound if release.id.nil?
+      update(release, tag, generate_body(issues))
+    rescue Octokit::NotFound
+      create(tag, generate_body(issues))
+    end
+
+    def self.generate_body(issues)
+      return "New Release" if issues.empty?
+
+      issues.map do |i|
+        "[##{i.number}](#{i.html_url}) - #{i.title}"
+      end.join("\n")
+    end
+
+    def self.create(tag, body)
+      puts "Creating release #{tag}..."
+      release = HubRelease.client.create_release(HubRelease.repo, tag, {
+        name: tag,
+        body: body,
+      })
+      puts release.html_url
+    end
+
+    def self.update(release, tag, body)
+      puts "Updating release #{tag}..."
+       HubRelease.client.update_release(release.url, tag, {
+        name: tag,
+        body: body,
+      })
+      puts release.html_url
+    end
+  end
+end


### PR DESCRIPTION
Add new `--init` option for generating the first release for a repo. Also included a small refactor to the structure of the project.

Close #1 
