### PR TITLE
Fix including labels in release note items

### DIFF
--- a/lib/hubrelease/releases.rb
+++ b/lib/hubrelease/releases.rb
@@ -23,9 +23,9 @@ module HubRelease
             if labels.include?(l.name)
               "_#{l.name}_"
             end
-          end.compact.uniq!
+          end
 
-          str += " (#{labels.join(", ")})"
+          str += " (#{labels_to_inc.join(", ")})" if labels_to_inc
         end
 
         str


### PR DESCRIPTION
Previously the labels option didn't work as intended, this fixes that.
