### PR TITLE
Add support for --master argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Simple install the gem:
 - `--attach` a path to the asset to attach to the release
 - `--init` create the first release for the repo
 - `--labels` a comma separated list (`--labels wontfix,question,enhancement`) to add to items
+- `--master` use `master` as the ref for the next release
 - `--new` the new release tag name (must exist on GitHub)
 - `--output` print the release notes instead of creating a release on GitHub
 - `--prerelease` mark the release as pre-release on GitHub
@@ -42,6 +43,14 @@ This will generate the very first release for a repository, you simply skip the
 `--prev` option and specify `--init` instead:
 
     hubrelease --repo zestia/hubrelease --init --new v0.0.1 --token $GITHUB_API_TOKEN
+
+### Generate With Master
+
+This will generate a new release notes between the given tag ref and `master`:
+
+    hubrelease --repo zestia/hubrelease --prev v0.1.0 --master --token $GITHUB_API_TOKEN
+
+This will always output the release note.
 
 ### Generate New Release
 

--- a/bin/hubrelease
+++ b/bin/hubrelease
@@ -24,6 +24,10 @@ opts = OptionParser.new do |o|
     options[:labels] = label
   end
 
+  o.on "--master", "Use master as the next release ref, will always output release notes" do |master|
+    options[:master] = master
+  end
+
   o.on "--new NEW", "Next release tag name" do |new|
     options[:new] = new
   end
@@ -63,6 +67,8 @@ begin
 
   if options[:init]
     mandatory = [:repo, :token, :new]
+  elsif options[:master]
+    mandatory = [:repo, :token, :prev]
   else
     mandatory = [:repo, :prev, :new, :token]
   end
@@ -80,4 +86,4 @@ rescue OptionParser::InvalidOption, OptionParser::MissingArgument
   exit
 end
 
-HubRelease::Generator.generate(options)
+HubRelease::Generator.run(options)


### PR DESCRIPTION
This generates release notes between the previous tag and the master ref. This will never create release notes on GitHub as there is no tag to create/update, so it always outputs in the terminal.