### PR TITLE
Remove empty brackets when using `--label` flag

### DIFF
--- a/lib/hubrelease/releases.rb
+++ b/lib/hubrelease/releases.rb
@@ -25,7 +25,7 @@ module HubRelease
             end
           end
 
-          str += " (#{labels_to_inc.join(", ")})" if labels_to_inc
+          str += " (#{labels_to_inc.join(", ")})" if labels_to_inc.size > 0
         end
 
         str


### PR DESCRIPTION
Empty brackets would be included because we checked if the variable was not `nil`. This fixes to not include empty brackets if there are no labels to add.