### PR TITLE
Add support for --branch argument

### DIFF
--- a/bin/hubrelease
+++ b/bin/hubrelease
@@ -15,6 +15,10 @@ opts = OptionParser.new do |o|
     options[:attach] << attach
   end
 
+  o.on "--branch BRANCH", "Branch to use as the next release ref, will always output release notes" do |branch|
+    options[:branch] = branch
+  end
+
   o.on "--init", "Generate first release" do |init|
     options[:init] = init
   end
@@ -67,7 +71,7 @@ begin
 
   if options[:init]
     mandatory = [:repo, :token, :new]
-  elsif options[:master]
+  elsif options[:master] || !options[:branch].nil?
     mandatory = [:repo, :token, :prev]
   else
     mandatory = [:repo, :prev, :new, :token]

--- a/lib/hubrelease/generator.rb
+++ b/lib/hubrelease/generator.rb
@@ -15,6 +15,11 @@ module HubRelease
           @output = true
         end
 
+        if !options[:branch].nil?
+          @head_tag = options[:branch]
+          @output = true
+        end
+
         @reverts = options[:reverts]
         @labels = options[:labels] || []
         @attachments = options[:attach] || []
@@ -23,7 +28,7 @@ module HubRelease
 
         if options[:init]
           generate_first
-        elsif options[:master]
+        elsif options[:master] || options[:branch]
           generate_partial
         else
           generate_new

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "----> Installing gem dependencies…"
+bundle install


### PR DESCRIPTION
This generates release notes between the previous tag and the specified branch ref. This will never create release notes on GitHub as there is no tag to create/update, so it always outputs in the terminal.