### PR TITLE
Add support for --draft flag

### DIFF
--- a/bin/hubrelease
+++ b/bin/hubrelease
@@ -19,6 +19,10 @@ opts = OptionParser.new do |o|
     options[:branch] = branch
   end
 
+  o.on "--draft", "Mark this release as a draft" do |draft|
+    options[:draft] = draft
+  end
+
   o.on "--init", "Generate first release" do |init|
     options[:init] = init
   end

--- a/lib/hubrelease/generator.rb
+++ b/lib/hubrelease/generator.rb
@@ -26,6 +26,7 @@ module HubRelease
         @watch = options[:watch] || []
 
         @prerelease = options[:prerelease] || false
+        @draft = options[:draft] || false
 
         if options[:init]
           generate_first
@@ -81,7 +82,7 @@ module HubRelease
         if @output
           HubRelease::Releases.output(issues, reverts, @labels, watched)
         else
-          HubRelease::Releases.create_or_update(@head_tag, issues, reverts, @labels, @attachments, @prerelease, watched)
+          HubRelease::Releases.create_or_update(@head_tag, issues, reverts, @labels, @attachments, @prerelease, @draft, watched)
         end
       end
 

--- a/lib/hubrelease/releases.rb
+++ b/lib/hubrelease/releases.rb
@@ -4,12 +4,15 @@ module HubRelease
       puts generate_body(issues, reverts, labels, watched)
     end
 
-    def self.create_or_update(tag, issues, reverts, labels, attachments, prerelease, watched)
-      release = HubRelease.client.release_for_tag(HubRelease.repo, tag)
-      raise Octokit::NotFound if release.id.nil?
-      update(release, tag, generate_body(issues, reverts, labels, watched), attachments, prerelease)
+    def self.create_or_update(tag, issues, reverts, labels, attachments, prerelease, draft, watched)
+      releases = HubRelease.client.list_releases(HubRelease.repo)
+      release = releases.find { |r| r.name == tag }
+
+      raise Octokit::NotFound if release.nil?
+
+      update(release, tag, generate_body(issues, reverts, labels, watched), attachments, prerelease, draft)
     rescue Octokit::NotFound
-      create(tag, generate_body(issues, reverts, labels, watched), attachments, prerelease)
+      create(tag, generate_body(issues, reverts, labels, watched), attachments, prerelease, draft)
     end
 
     def self.generate_body(issues, reverts, labels, watched)
@@ -47,25 +50,35 @@ module HubRelease
       body
     end
 
-    def self.create(tag, body, attachments, prerelease)
+    def self.create(tag, body, attachments, prerelease, draft)
       puts "Creating release #{tag}..."
+
       release = HubRelease.client.create_release(HubRelease.repo, tag, {
         name: tag,
+        tag_name: tag,
         body: body,
         prerelease: prerelease,
+        draft: draft,
       })
+
       puts release.html_url
+
       upload_attachments(release, attachments)
     end
 
-    def self.update(release, tag, body, attachments, prerelease)
+    def self.update(release, tag, body, attachments, prerelease, draft)
       puts "Updating release #{tag}..."
+
        HubRelease.client.update_release(release.url, {
         name: tag,
+        tag_name: tag,
         body: body,
         prerelease: prerelease,
+        draft: draft,
       })
+
       puts release.html_url
+
       upload_attachments(release, attachments)
     end
 

--- a/lib/hubrelease/releases.rb
+++ b/lib/hubrelease/releases.rb
@@ -55,16 +55,7 @@ module HubRelease
         prerelease: prerelease,
       })
       puts release.html_url
-
-      if attachments.size > 0
-        attachments.each do |a|
-          begin
-            HubRelease.client.upload_asset(release.url, a)
-          rescue Octokit::MissingContentType
-            HubRelease.client.upload_asset(release.url, a, :content_type => "application/octet-stream")
-          end
-        end
-      end
+      upload_attachments(release, attachments)
     end
 
     def self.update(release, tag, body, attachments, prerelease)
@@ -75,7 +66,10 @@ module HubRelease
         prerelease: prerelease,
       })
       puts release.html_url
+      upload_attachments(release, attachments)
+    end
 
+    def self.upload_attachments(release, attachments)
       if attachments.size > 0
         attachments.each do |a|
           begin


### PR DESCRIPTION
Adds support for `--draft`, this will mark a release as draft, subsequent runs without `--draft` will publish that release for that release name.