### PR TITLE
Add pagination to the issues fetching

### DIFF
--- a/lib/hubrelease/issues.rb
+++ b/lib/hubrelease/issues.rb
@@ -7,7 +7,17 @@ module HubRelease
     def self.fetch(since = nil)
       params = { state: "closed" }
       params[:since] = since.iso8601 unless since.nil?
-      HubRelease.client.issues(HubRelease.repo, params)
+
+      issues = HubRelease.client.issues(HubRelease.repo, params)
+
+      last_response = HubRelease.client.last_response
+
+      until last_response.rels[:next].nil?
+        last_response = last_response.rels[:next].get
+        issues.concat last_response.data
+      end
+
+      issues
     end
 
     def self.filter_closed_before(issues, date)


### PR DESCRIPTION
Made the mistake that Octokit doesn't auto paginate, rather than turn on the global pagination, just paginate the fetching of issues.